### PR TITLE
implemented atLeastOnce delivery guarantee

### DIFF
--- a/ws_server/dist/index.js
+++ b/ws_server/dist/index.js
@@ -88,6 +88,18 @@ const fetchMessages = () => __awaiter(void 0, void 0, void 0, function* () {
     let messageArr = yield MgRequest.find().sort({ _id: -1 }).limit(5);
     return messageArr;
 });
+// --------- atLeastOnce logic helper Fns START ---------//
+const fetchMissedEvents = (offset) => __awaiter(void 0, void 0, void 0, function* () {
+    console.log('#fetchMissedEvents Offset passed', offset);
+    let messageArr = yield MgRequest.find({ createdAt: { $gt: offset } });
+    return messageArr;
+});
+// const fetchMissedEvents = async (offset: Date) => {
+//   let rName = "room 1";
+//   let messageArr: IMgRequest[] = await MgRequest.find({ 'room.roomName': "room 1", 'room.timestamp': {$gt: `offset`} });
+//   return messageArr;
+// }
+// --------- atLeastOnce logic helper Fns END ---------//
 io.use((socket, next) => {
     const currentSessionID = socket.handshake.auth.sessionId;
     console.log("Middleware executed");
@@ -110,7 +122,10 @@ io.on('connection', (socket) => __awaiter(void 0, void 0, void 0, function* () {
     if (reconnect) {
         console.log('A user re-connected');
         socket.join("room 1");
-        let messageArr = yield fetchMessages();
+        console.log('Offset when reconnected:', socket.handshake.auth.offset);
+        // let messageArr = await fetchMessages();
+        let messageArr = yield fetchMissedEvents(socket.handshake.auth.offset);
+        console.log('fetched missed messages', messageArr);
         messageArr.forEach(message => {
             let msg = message.room.roomData;
             socket.emit("connect_message", msg);
@@ -119,6 +134,8 @@ io.on('connection', (socket) => __awaiter(void 0, void 0, void 0, function* () {
     else {
         console.log('A user connected first time');
         socket.join("room 1");
+        socket.handshake.auth.offset = undefined;
+        console.log('Initial Offset on first connection:', socket.handshake.auth.offset);
         socket.emit("session", {
             sessionId: socket.data.sessionId,
         });
@@ -133,6 +150,27 @@ io.on('connection', (socket) => __awaiter(void 0, void 0, void 0, function* () {
         console.log('user disconnected');
     });
 }));
+/// atLeastOnce server-side START ////////
+// io.on("connection", async (socket) => {
+//   const offset = socket.handshake.auth.offset;
+//   if (offset) {
+//     // this is a reconnection
+//     for (const event of await fetchMissedEventsFromDatabase(offset)) {
+//       socket.emit("my-event", event);
+//     }
+//   } else {
+//     // this is a first connection
+//   }
+// });
+// setInterval(async () => {
+//   const event = {
+//     id: generateUniqueId(),
+//     data: new Date().toISOString()
+//   }
+//   await persistEventToDatabase(event);
+//   io.emit("my-event", event);
+// }, 1000);
+/// atLeastOnce server-side END ////////
 // Backend API
 app.get('/', (req, res) => {
     console.log("you've got mail!");
@@ -146,11 +184,13 @@ app.put('/api/postman', (req, res) => __awaiter(void 0, void 0, void 0, function
     const currentRequest = new MgRequest({
         room: {
             roomName: "room 1",
-            roomData: data,
+            roomData: data
         },
     });
     const savedRequest = yield currentRequest.save();
-    io.to("room 1").emit("message", data);
+    const timestamp = savedRequest.createdAt;
+    let messageData = [data, timestamp];
+    io.to("room 1").emit("message", messageData);
     console.log('SENT POSTMAN MESSAGE');
     res.send('ok');
 }));

--- a/ws_server/dist/models/request.js
+++ b/ws_server/dist/models/request.js
@@ -2,12 +2,20 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 // const mongoose = require('mongoose');
 const mongoose_1 = require("mongoose");
+// const requestSchema = new Schema<IMgRequest>({
+//   room: {
+//     type: Object,
+//     required: true,
+//   }
+// })
+// --- atLeastOnce logic
+// creating a timestamp via Mongoose
 const requestSchema = new mongoose_1.Schema({
     room: {
         type: Object,
-        required: true
+        required: true,
     }
-});
+}, { timestamps: true });
 requestSchema.set('toJSON', {
     transform: (document, returnedObject) => {
         // returnedObject.id = returnedObject._id.toString()

--- a/ws_server/src/index.ts
+++ b/ws_server/src/index.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from "express";
 import { createServer } from "http";
 import { Server } from "socket.io";
-import { Document } from 'mongoose';
+import { Date, Document } from 'mongoose';
 import { v4 as uuid4 } from 'uuid';
 const express = require('express');
 const app = express();
@@ -98,7 +98,7 @@ interface IMgRequest extends Document<any> {
 
 interface ClientToServerEvents {
   hello: () => void;
-  message: (message: String) => void;
+  message: (message: any[]) => void;
   connect_message: (message: RoomData) => void;
   session: (message: SessionObject) => void;
 }
@@ -111,6 +111,7 @@ interface SocketData {
   name: string;
   age: number;
   sessionId: string;
+  offset: Date; // createdAt is a Mongoose prop of type Date
 }
 
 interface SessionObject {
@@ -138,10 +139,18 @@ let reconnect: boolean = false;
 
 let currentSessions: SessionObject[] = []
 
-const fetchMessages = async () => {
-  let messageArr: IMgRequest[] = await MgRequest.find().sort({ _id: -1 }).limit(5);
+// const fetchMessages = async () => {
+//   let messageArr: IMgRequest[] = await MgRequest.find().sort({ _id: -1 }).limit(5);
+//   return messageArr;
+// }
+
+
+const fetchMissedMessages = async (offset: Date)=> {
+  console.log('#fetchMissedMessages Offset passed', offset)
+  let messageArr: IMgRequest[] = await MgRequest.find({ createdAt: {$gt: offset} });
   return messageArr;
 }
+
 
 io.use((socket, next) => {
   const currentSessionID = socket.handshake.auth.sessionId;
@@ -168,21 +177,20 @@ io.use((socket, next) => {
 
 io.on('connection', async (socket) => {
   if (reconnect) {
-
     console.log('A user re-connected');
-
+    
     socket.join("room 1");
+    
+    let messageArr = await fetchMissedMessages(socket.handshake.auth.offset)
 
-    let messageArr = await fetchMessages();
     messageArr.forEach(message => {
       let msg = message.room.roomData
       socket.emit("connect_message", msg);
     });
-
   } else {
     console.log('A user connected first time');
     socket.join("room 1");
-
+    socket.handshake.auth.offset = undefined
     socket.emit("session", {
       sessionId: socket.data.sessionId,
     })
@@ -190,7 +198,6 @@ io.on('connection', async (socket) => {
 
 
   socket.on("disconnecting", (reason) => {
-
     if (reason === "client namespace disconnect") {
       reconnect = true;
       // push an object with session_id and unintentionalDisconnect
@@ -202,6 +209,21 @@ io.on('connection', async (socket) => {
   });
 });
 
+/// atLeastOnce server-side START ////////
+
+// io.on("connection", async (socket) => {
+//   const offset = socket.handshake.auth.offset;
+//   if (offset) {
+//     // this is a reconnection
+//     for (const event of await fetchMissedEventsFromDatabase(offset)) {
+//       socket.emit("my-event", event);
+//     }
+//   } else {
+//     // this is a first connection
+//   }
+// });
+
+/// atLeastOnce server-side END ////////
 
 // Backend API
 
@@ -219,13 +241,16 @@ app.put('/api/postman', async (req: Request, res: Response) => {
   const currentRequest = new MgRequest({
     room: {
       roomName: "room 1",
-      roomData: data,
+      roomData: data
     },
   });
 
   const savedRequest = await currentRequest.save();
 
-  io.to("room 1").emit("message", data);
+  const timestamp: Date = savedRequest.createdAt
+  let messageData: any[] = [data, timestamp]
+  
+  io.to("room 1").emit("message", messageData);
 
   console.log('SENT POSTMAN MESSAGE');
 

--- a/ws_server/src/models/request.ts
+++ b/ws_server/src/models/request.ts
@@ -12,12 +12,22 @@ interface IMgRequest extends Document<any> {
   },
 }
 
+// const requestSchema = new Schema<IMgRequest>({
+//   room: {
+//     type: Object,
+//     required: true,
+//   }
+// })
+
+// --- atLeastOnce logic
+// creating a timestamp via Mongoose
 const requestSchema = new Schema<IMgRequest>({
   room: {
     type: Object,
-    required: true
-  }
-})
+    required: true,
+  }},
+  { timestamps: true }, // creates timestamp
+)
 
 requestSchema.set('toJSON', {
   transform: (document: Document<any>, returnedObject: Document<any>) => {


### PR DESCRIPTION
**Client-side**
- Updated the offset value with each message received from the server.
- Added a `setTimeout()` Fn that wraps around the `socket.connect()` call so that when a user clicks `disconnect` there's a slight delay before they reconnect. This allows us to test whether _missed messages_ (i.e., messages sent while the user was disconnected) are received.


**Server-side**
- Updated Mongoose schema (`request.ts`) to include timestamps. `{timestamps: true}` automatically creates 2 properties on the document; `createdAt` and `updatedAt`. This timestamp serves as the end user's offset value (i.e., what we'll use to determine what messages were missed when user is disconnected)

- Updated the `index.ts` file
   - Replaced the `fetchMessages` function with `fetchMissedMessages(offset)` within the reconnection logic of `io.on("connection"...)`. This function takes 1 argument, `offset`, which it uses to fetch messages in the database that are older than it's value (i.e., the last message received by the user).
   - Updated `/api/postman` PUT route to capture the `createdAt` value of the persisted message and emit it along with the data to the client.