### PR TITLE
clients join rooms; postman emits to specific rooms

### DIFF
--- a/chat_app/public/services/messages.js
+++ b/chat_app/public/services/messages.js
@@ -44,7 +44,7 @@ socket.on("message", (messageData) => {
   
   const messages = document.getElementById('messages');
   const item = document.createElement('li');
-  item.textContent = msg["hi"];
+  item.textContent = msg["message"];
   messages.appendChild(item);
   window.scrollTo(0, document.body.scrollHeight);
 });
@@ -52,7 +52,7 @@ socket.on("message", (messageData) => {
 socket.on("connect_message", (msg) => {
   // socket.auth.offset = timestamp; // w/o this update, user will always receive messages from a specific point in time on
   const item = document.createElement('li');
-  item.textContent = msg["hi"];
+  item.textContent = msg["message"];
   messages.appendChild(item);
   window.scrollTo(0, document.body.scrollHeight);
 });
@@ -124,8 +124,15 @@ document.addEventListener('DOMContentLoaded', () => {
   const options = document.getElementById('options');
 
   options.addEventListener('change', () => {
-      const selectedOption = options.value;
+    const selectedOption = options.value;
 
-      alert(`You're now in room: ${selectedOption}`);
+    // join room <button value> on change event
+    // server then emits back to roomJoined (below)
+    socket.emit('join', `${selectedOption}`);
   });
+});
+
+// catches roomJoined event
+socket.on('roomJoined', (message) => {
+  console.log(message);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "app_demo_v2",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/ws_server/dist/index.js
+++ b/ws_server/dist/index.js
@@ -9,7 +9,7 @@ const cors = require('cors');
 const httpServer = (0, http_1.createServer)(app);
 require("dotenv").config();
 const { sessionIdMiddleware, handleConnection } = require('./services/socketServices');
-const { homeRoute, mongoPostmanRoute, dynamoPostmanRoute } = require('./services/expressServices');
+const { homeRoute, mongoPostmanRoute, mongoPostmanRoomsRoute, dynamoPostmanRoute } = require('./services/expressServices');
 // Express Middleware
 app.use(cors({
     origin: 'http://localhost:3002', // Replace with your client's origin
@@ -29,6 +29,7 @@ exports.io.on("connection", handleConnection);
 // Backend API
 app.get('/', homeRoute);
 app.put('/api/postman', mongoPostmanRoute);
+app.put('/api/postman/rooms', mongoPostmanRoomsRoute);
 app.post('/api/postman/dynamo', dynamoPostmanRoute);
 // listening on port 3001
 httpServer.listen(PORT, () => {

--- a/ws_server/dist/services/expressServices.js
+++ b/ws_server/dist/services/expressServices.js
@@ -12,7 +12,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.dynamoPostmanRoute = exports.mongoPostmanRoute = exports.homeRoute = void 0;
+exports.dynamoPostmanRoute = exports.mongoPostmanRoomsRoute = exports.mongoPostmanRoute = exports.homeRoute = void 0;
 const index_1 = require("../index");
 const { connect } = require("mongoose");
 const MgRequest = require('../db/mongoService');
@@ -52,6 +52,24 @@ const mongoPostmanRoute = (req, res) => __awaiter(void 0, void 0, void 0, functi
     res.send('ok');
 });
 exports.mongoPostmanRoute = mongoPostmanRoute;
+const mongoPostmanRoomsRoute = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
+    const data = req.body;
+    console.log('ROOM AND MESSAGE:', data.room, data.message);
+    const currentRequest = new MgRequest({
+        room: {
+            roomName: data.room,
+            roomData: data.message
+        },
+    });
+    const savedRequest = yield currentRequest.save();
+    const timestamp = savedRequest.createdAt;
+    let messageData = [data, timestamp];
+    // only people in this room should receive this message event
+    index_1.io.to(`${data.room}`).emit("roomJoined", messageData);
+    console.log('SENT POSTMAN MESSAGE');
+    res.send('ok');
+});
+exports.mongoPostmanRoomsRoute = mongoPostmanRoomsRoute;
 const dynamoPostmanRoute = (req, res) => __awaiter(void 0, void 0, void 0, function* () {
     try {
         const data = req.body; // specify the actual type

--- a/ws_server/dist/services/socketServices.js
+++ b/ws_server/dist/services/socketServices.js
@@ -38,7 +38,14 @@ const sessionIdMiddleware = (socket, next) => {
     next();
 };
 exports.sessionIdMiddleware = sessionIdMiddleware;
+// called when io.on(connect)
 const handleConnection = (socket) => __awaiter(void 0, void 0, void 0, function* () {
+    socket.on('join', (roomName) => {
+        socket.join(roomName); // Join the specified room
+        console.log(`Client has joined room: ${roomName}`);
+        // Emit something to the client that just joined the room
+        socket.emit('roomJoined', `You have joined room: ${roomName}`);
+    });
     if (reconnect) {
         console.log('A user re-connected');
         socket.join("room 1");

--- a/ws_server/src/index.ts
+++ b/ws_server/src/index.ts
@@ -9,9 +9,8 @@ const httpServer = createServer(app);
 
 require("dotenv").config();
 
-
 const { sessionIdMiddleware, handleConnection } = require('./services/socketServices')
-const { homeRoute, mongoPostmanRoute, dynamoPostmanRoute } = require('./services/expressServices')
+const { homeRoute, mongoPostmanRoute, mongoPostmanRoomsRoute, dynamoPostmanRoute } = require('./services/expressServices')
 
 // Express Middleware
 
@@ -32,12 +31,13 @@ interface ServerToClientEvents {
 }
 
 interface RoomData {
-  hi: string;
+  message: string;
 }
 
 interface ClientToServerEvents {
   hello: () => void;
   message: (message: any[]) => void;
+  roomJoined: (message: any[]) => void;
   connect_message: (message: RoomData) => void;
   session: (message: SessionObject) => void;
 }
@@ -80,6 +80,7 @@ io.on("connection", handleConnection)
 
 app.get('/', homeRoute);
 app.put('/api/postman', mongoPostmanRoute);
+app.put('/api/postman/rooms', mongoPostmanRoomsRoute);
 app.post('/api/postman/dynamo', dynamoPostmanRoute);
 
 // listening on port 3001

--- a/ws_server/src/services/expressServices.ts
+++ b/ws_server/src/services/expressServices.ts
@@ -16,7 +16,6 @@ async function run() {
   });
 }
 
-
 export const homeRoute = (req: Request, res: Response) => {
   console.log("you've got mail!");
   res.send('Nice work')
@@ -41,6 +40,38 @@ export const mongoPostmanRoute = async (req: Request, res: Response) => {
   let messageData: any[] = [data, timestamp]
 
   io.to("room 1").emit("message", messageData);
+
+  console.log('SENT POSTMAN MESSAGE');
+
+  res.send('ok');
+}
+
+export const mongoPostmanRoomsRoute = async (req: Request, res: Response) => {
+  // accept postman put request
+  // publish this request.body data via websocket emit
+  interface jsonData {
+    room: string;
+    message: string;
+  }
+  
+  const data: jsonData = req.body
+
+  console.log('ROOM AND MESSAGE:', data.room, data.message);
+  
+  const currentRequest = new MgRequest({
+    room: {
+      roomName: data.room,
+      roomData: data.message
+    },
+  });
+
+  const savedRequest = await currentRequest.save();
+
+  const timestamp: Date = savedRequest.createdAt
+  let messageData: any[] = [data, timestamp]
+
+  // only people in this room should receive this message event
+  io.to(`${data.room}`).emit("roomJoined", messageData);
 
   console.log('SENT POSTMAN MESSAGE');
 

--- a/ws_server/src/services/socketServices.ts
+++ b/ws_server/src/services/socketServices.ts
@@ -10,7 +10,7 @@ interface SessionObject {
 }
 
 interface RoomData {
-  hi: string;
+  message: string;
 }
 
 interface IMgRequest extends Document<any> {
@@ -54,7 +54,17 @@ export const sessionIdMiddleware = (socket: Socket, next: NextFunction) => {
   next();
 }
 
+// called when io.on(connect)
 export const handleConnection = async (socket: Socket) => {
+
+  socket.on('join', (roomName) => {
+    socket.join(roomName); // Join the specified room
+    console.log(`Client has joined room: ${roomName}`);
+
+    // Emit something to the client that just joined the room
+    socket.emit('roomJoined', `You have joined room: ${roomName}`);
+  });
+
   if (reconnect) {
     console.log('A user re-connected');
 
@@ -76,7 +86,6 @@ export const handleConnection = async (socket: Socket) => {
     })
   }
 }
-
 
 /// atLeastOnce server-side START ////////
 


### PR DESCRIPTION
- based on my tests, this new feature does not break or change any existing features
- **however**, interface `RoomData` now has 'message' in place of 'hi'; Postman requests should reflect that
- `'/api/postman/rooms' `is a new route in index.ts
- `mongoPostmanRoomsRoute` (new func in expressServices) handles the new route logic
- `mongoPostmanRoomsRoute` expects the requests from Postman to have ‘message’ and ‘room’ properties
- upon receiving a new Postman request, `mongoPostmanRoomsRoute` emits the messageData to the room specified in the ‘room’ property of the request
- the messageData will only be logged in the browser console if the client has joined that same room, of the name in the ‘room’ property
- the client can join a room by clicking one of the buttons Chris implemented (‘room’ value in Postman requests should be A, B, C, or D to match the button values)
- clicking a button emits a ‘join’ event from the client with a specified room name (the button value)
- the server is listening for that event in `handleConnection` (added to the top) and, when triggered, will add the client to the specified room
- the server then emits back to the client: `You have joined room: ${roomName}` via the `roomJoined` event (which the client is listening for; bottom of messages.js)
- only then will the client receive emissions to that room (coming from PUT '/api/postman/rooms' requests)