### PR TITLE
Session id bug

### DIFF
--- a/chat_app/public/services/messages.js
+++ b/chat_app/public/services/messages.js
@@ -26,7 +26,7 @@ socket.on("message", (messageData) => {
 });
 
 socket.on("connect_message", (msg) => {
-  // socket.auth.offset = timestamp; // w/o this update, user will always receive messages from a specific point in time on
+  socket.auth.offset = timestamp; // w/o this update, user may always receive messages from a specific point in time on
   const item = document.createElement('li');
   item.textContent = msg["hi"];
   messages.appendChild(item);
@@ -39,32 +39,6 @@ socket.on("session", ({ sessionId }) => {
   localStorage.setItem("sessionId", sessionId);
 })
 
-// ----- atLeastOnce server-side START ---------//
-
-
-// Client
-// const socket = io({
-//   auth: {
-//     offset: undefined
-//   }
-// });
-
-// socket.on("my-event", ({ timestamp, data }) => {
-//   // do something with the data, and then update the offset
-//   socket.auth.offset = timestamp;
-// });
-
-
-// ----- atLeastOnce server-side END ---------//
-
-
-// socket.on("message", (msg) => {
-//   console.log(msg);
-//   const item = document.createElement('li');
-//   item.textContent = msg["hi"];
-//   messages.appendChild(item);
-//   window.scrollTo(0, document.body.scrollHeight);
-// });
 
 // // const form = document.getElementById('form');
 // // const input = document.getElementById('input');

--- a/chat_app/public/services/messages.js
+++ b/chat_app/public/services/messages.js
@@ -1,21 +1,24 @@
 // Connect to the Socket.IO server
-const socket = io('http://localhost:3001');
+// const socket = io('http://localhost:3001');
+
+// const socket = io('44.212.23.240:3001');
 
 // -----  atLeastOnce logic
-// const socket = io('http://localhost:3001', { 
-//   auth: {
-//     offset: undefined
-//   }
-// });
+const socket = io('http://localhost:3001', {
+  auth: {
+    offset: undefined,
+    sessionId: localStorage.getItem("sessionId") || undefined,
+  }
+});
 
 // Handle successful connection
 socket.on("message", (messageData) => {
   console.log('MessageData from client', messageData);
-  let [ msg, timestamp ] = messageData;
+  let [msg, timestamp] = messageData;
 
   socket.auth.offset = timestamp; // atLeastOnce logic
   console.log('Socket offset', socket.auth.offset)
-  
+
   const item = document.createElement('li');
   item.textContent = msg["hi"];
   messages.appendChild(item);

--- a/ws_server/dist/services/socketServices.js
+++ b/ws_server/dist/services/socketServices.js
@@ -21,9 +21,13 @@ const fetchMissedMessages = (offset) => __awaiter(void 0, void 0, void 0, functi
 });
 const sessionIdMiddleware = (socket, next) => {
     const currentSessionID = socket.handshake.auth.sessionId;
+    console.log('\n');
+    console.log('######## NEW TEST ##########');
     console.log("Middleware executed");
-    console.log(currentSessionID);
+    // console.log(socket.data.sessionId);
+    console.log("currentSessionID:", currentSessionID);
     console.log(currentSessions);
+    console.log('\n');
     if (currentSessionID) {
         const session = currentSessions.find(obj => obj.sessionId === currentSessionID);
         if (session) {
@@ -35,6 +39,8 @@ const sessionIdMiddleware = (socket, next) => {
     let randomID = (0, uuid_1.v4)();
     socket.data.sessionId = randomID;
     currentSessions.push({ sessionId: randomID });
+    // console.log(currentSessions);
+    // console.log('\n');
     next();
 };
 exports.sessionIdMiddleware = sessionIdMiddleware;

--- a/ws_server/src/services/socketServices.ts
+++ b/ws_server/src/services/socketServices.ts
@@ -33,9 +33,14 @@ const fetchMissedMessages = async (offset: Date) => {
 
 export const sessionIdMiddleware = (socket: Socket, next: NextFunction) => {
   const currentSessionID = socket.handshake.auth.sessionId
+
+  console.log('\n')
+  console.log('######## NEW TEST ##########')
   console.log("Middleware executed");
-  console.log(currentSessionID);
+  // console.log(socket.data.sessionId);
+  console.log("currentSessionID:", currentSessionID);
   console.log(currentSessions);
+  console.log('\n');
 
   if (currentSessionID) {
     const session = currentSessions.find(obj => obj.sessionId === currentSessionID);
@@ -50,6 +55,9 @@ export const sessionIdMiddleware = (socket: Socket, next: NextFunction) => {
   socket.data.sessionId = randomID;
 
   currentSessions.push({ sessionId: randomID });
+
+  // console.log(currentSessions);
+  // console.log('\n');
 
   next();
 }


### PR DESCRIPTION
- Fixed bug with `sessionId` , now `sessionId` persists for both unintentional and intentional disconnects
- Changed code on the client side in `messages.js` on line 10 to retrieve the current value of `"sessionId"` if it exists, and otherwise set it to `undefined` 
- Refactored code on the server side in `socketServices.ts`, on lines 31-34 created a reusable `isReconnect` function that determines if the client is currently connecting for the first time or is a reconnect 