### PR TITLE
Updated code to ESM modules

### DIFF
--- a/ws_server/package.json
+++ b/ws_server/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "tsc && node dist/index.js",
@@ -24,7 +25,7 @@
     "@aws-sdk/credential-providers": "^3.430.0",
     "@aws-sdk/lib-dynamodb": "^3.430.0",
     "cors": "^2.8.5",
-    "dotenv": "^8.2.0",
+    "dotenv": "^8.6.0",
     "express": "^4.18.2",
     "mongodb": "^6.1.0",
     "mongoose": "^5.13.20",
@@ -33,6 +34,7 @@
   },
   "devDependencies": {
     "@types/cors": "^2.8.13",
+    "@types/dotenv": "^8.2.0",
     "@types/express": "^4.17.17",
     "@types/uuid": "^9.0.5",
     "@typescript-eslint/eslint-plugin": "^6.2.0",

--- a/ws_server/src/db/dynamoService.ts
+++ b/ws_server/src/db/dynamoService.ts
@@ -1,13 +1,13 @@
 import { v4 as uuid4 } from 'uuid';
-import { 
-	DynamoDBClient, 
-	DynamoDBClientConfig,
-	ScanCommand
+import {
+  DynamoDBClient,
+  DynamoDBClientConfig,
+  ScanCommand
 } from "@aws-sdk/client-dynamodb";
-import { 
-	GetCommand,
-	PutCommand, 
-	DynamoDBDocumentClient 
+import {
+  GetCommand,
+  PutCommand,
+  DynamoDBDocumentClient
 } from "@aws-sdk/lib-dynamodb";
 import { fromEnv } from "@aws-sdk/credential-providers";
 
@@ -20,18 +20,18 @@ const createMessage = async (room_id: string, message: string) => {
     TableName: "Messages",
     Item: {
       Id: uuid4(),
-			TimeCreated: Date.now(),
-			RoomId: room_id,
+      TimeCreated: Date.now(),
+      RoomId: room_id,
       Message: {
-				hi: message
-			} 
+        hi: message
+      }
     },
   });
 
   try {
     const response = await docClient.send(command);
 
-		// console.log('');
+    // console.log('');
     // console.log('pushToDynamo -----------------------------------------------');
     // console.log("response httpStatusCode:", response['$metadata']['httpStatusCode']);
     // console.log('');
@@ -44,8 +44,8 @@ const createMessage = async (room_id: string, message: string) => {
 
 const readPreviousMessages = async (room_id: string, messagesToFetch: number) => {
   try {
-    const command = new ScanCommand({ 
-			TableName: "Messages",
+    const command = new ScanCommand({
+      TableName: "Messages",
       FilterExpression: "#RoomId = :roomId",
       ExpressionAttributeNames: {
         "#RoomId": "RoomId",
@@ -53,11 +53,11 @@ const readPreviousMessages = async (room_id: string, messagesToFetch: number) =>
       ExpressionAttributeValues: {
         ":roomId": { S: room_id },
       },
-      Limit: messagesToFetch, 
-		});
+      Limit: messagesToFetch,
+    });
 
     const response = await client.send(command);
-		// console.log("readPreviousMessage invoked:", response.Items);
+    // console.log("readPreviousMessage invoked:", response.Items);
     return response;
   } catch (error) {
     console.error(error);
@@ -66,15 +66,15 @@ const readPreviousMessages = async (room_id: string, messagesToFetch: number) =>
 
 const readMessage = async () => {
   try {
-    const command = new GetCommand({ 
+    const command = new GetCommand({
       Key: {
         Id: '020b582e-8d51-4039-b155-d0b13eb140a6',
-				TimeCreated: 1697654497057
+        TimeCreated: 1697654497057
       },
       TableName: "Messages"
     });
     const response = await client.send(command);
-		// console.log("readMessage", response.Item);
+    // console.log("readMessage", response.Item);
     return response;
   } catch (error) {
     console.error(error);
@@ -84,7 +84,7 @@ const readMessage = async () => {
 // readPreviousMessages('G', 5);
 
 export default {
-	createMessage,
-	readMessage,
-	readPreviousMessages
+  createMessage,
+  readMessage,
+  readPreviousMessages
 }

--- a/ws_server/src/db/mongoService.ts
+++ b/ws_server/src/db/mongoService.ts
@@ -1,8 +1,10 @@
 // const mongoose = require('mongoose');
-import { Document, Schema, model } from 'mongoose';
+import { Date, Document } from "mongoose";
+import pkg from "mongoose";
+const { Schema, model } = pkg;
 
 interface RoomData {
-  hi: string;
+  message: string;
 }
 
 interface IMgRequest extends Document<any> {
@@ -10,6 +12,8 @@ interface IMgRequest extends Document<any> {
     roomName: string,
     roomData: RoomData
   },
+  createdAt: Date,
+  updatedAt: Date
 }
 
 // const requestSchema = new Schema<IMgRequest>({
@@ -25,7 +29,8 @@ const requestSchema = new Schema<IMgRequest>({
   room: {
     type: Object,
     required: true,
-  }},
+  }
+},
   { timestamps: true }, // creates timestamp
 )
 
@@ -37,6 +42,5 @@ requestSchema.set('toJSON', {
   }
 })
 
-const MgRequest = model<IMgRequest>('MgRequest', requestSchema);
+export const MgRequest = model<IMgRequest>('MgRequest', requestSchema);
 
-module.exports = MgRequest

--- a/ws_server/src/index.ts
+++ b/ws_server/src/index.ts
@@ -1,16 +1,14 @@
 import { createServer } from "http";
 import { Server } from "socket.io";
 import { Date } from 'mongoose';
-
-const express = require('express');
+import express from 'express';
+import cors from 'cors';
+import "dotenv/config"
 const app = express();
-const cors = require('cors');
 const httpServer = createServer(app);
 
-require("dotenv").config();
-
-const { sessionIdMiddleware, handleConnection } = require('./services/socketServices')
-const { homeRoute, mongoPostmanRoute, mongoPostmanRoomsRoute, dynamoPostmanRoute } = require('./services/expressServices')
+import { sessionIdMiddleware, handleConnection } from './services/socketServices.js';
+import { homeRoute, mongoPostmanRoute, mongoPostmanRoomsRoute, dynamoPostmanRoute } from './services/expressServices.js';
 
 // Express Middleware
 
@@ -73,8 +71,8 @@ export const io = new Server<
 
 // WS Server Logic
 
-io.use(sessionIdMiddleware)
-io.on("connection", handleConnection)
+io.use(sessionIdMiddleware);
+io.on("connection", handleConnection);
 
 // Backend API
 

--- a/ws_server/src/services/expressServices.ts
+++ b/ws_server/src/services/expressServices.ts
@@ -1,9 +1,18 @@
 import { Request, Response } from "express";
-import { io } from '../index';
-const { connect } = require("mongoose");
-const MgRequest = require('../db/mongoService');
-import dynamoService from "../db/dynamoService";
+import { io } from '../index.js';
+import pkg from "mongoose";
+const { connect } = pkg;
+import { MgRequest } from '../db/mongoService.js';
+import dynamoService from "../db/dynamoService.js";
 import { Date } from 'mongoose';
+
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      ENV_DB: string;
+    }
+  }
+}
 
 // code from Mongoose Typescript Support
 run().catch(err => console.log(err));
@@ -53,11 +62,11 @@ export const mongoPostmanRoomsRoute = async (req: Request, res: Response) => {
     room: string;
     message: string;
   }
-  
+
   const data: jsonData = req.body
 
   console.log('ROOM AND MESSAGE:', data.room, data.message);
-  
+
   const currentRequest = new MgRequest({
     room: {
       roomName: data.room,

--- a/ws_server/src/services/socketServices.ts
+++ b/ws_server/src/services/socketServices.ts
@@ -1,9 +1,8 @@
 import { v4 as uuid4 } from 'uuid';
 import { Socket } from "socket.io";
-import { NextFunction } from 'express';
 import { Date, Document } from 'mongoose';
 
-const MgRequest = require('../db/mongoService');
+import { MgRequest } from '../db/mongoService.js';
 
 interface SessionObject {
   sessionId: string;
@@ -22,6 +21,7 @@ interface IMgRequest extends Document<any> {
   updatedAt: Date
 }
 
+//
 let currentSessions: SessionObject[] = []
 
 const fetchMissedMessages = async (offset: Date) => {
@@ -34,7 +34,7 @@ const isReconnect = (socket: Socket) => {
   return currentSessions.find(obj => obj.sessionId === currentSessionID);
 }
 
-export const sessionIdMiddleware = (socket: Socket, next: NextFunction) => {
+export const sessionIdMiddleware = (socket: Socket, next: () => void) => {
   const session = isReconnect(socket);
 
   // console.log('\n')

--- a/ws_server/tsconfig.json
+++ b/ws_server/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     /* Visit https://aka.ms/tsconfig to read more about this file */
-
     /* Projects */
     // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
     // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
@@ -9,9 +8,8 @@
     // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
     // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
-
     /* Language and Environment */
-    "target": "es2015",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "target": "es2015", /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
     // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
@@ -23,12 +21,11 @@
     // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
-
     /* Modules */
-    "module": "commonjs",                                /* Specify what module code is generated. */
-    "rootDir": "./src",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    "module": "NodeNext", /* Specify what module code is generated. */
+    "rootDir": "./src", /* Specify the root folder within your source files. */
+    "moduleResolution": "NodeNext", /* Specify how TypeScript looks up a file from a given module specifier. */
+    "baseUrl": "./", /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
@@ -42,12 +39,10 @@
     // "resolveJsonModule": true,                        /* Enable importing .json files. */
     // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
     // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
-
     /* JavaScript Support */
     // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
     // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
     // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
-
     /* Emit */
     // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
@@ -55,7 +50,7 @@
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./dist",                                   /* Specify an output folder for all emitted files. */
+    "outDir": "./dist", /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
@@ -72,17 +67,15 @@
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */
-
     /* Interop Constraints */
     // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
     // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
     // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
-    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    "esModuleInterop": true, /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
     // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
-
+    "forceConsistentCasingInFileNames": true, /* Ensure that casing is correct in imports. */
     /* Type Checking */
-    "strict": true,                                      /* Enable all strict type-checking options. */
+    "strict": true, /* Enable all strict type-checking options. */
     // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
     // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
     // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
@@ -101,13 +94,13 @@
     // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
     // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
     // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
-
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true                                 /* Skip type checking all .d.ts files. */
+    "skipLibCheck": true /* Skip type checking all .d.ts files. */
   },
-  "include": ["./src/**/*"],
+  "include": [
+    "./src/**/*"
+  ],
   "$schema": "https://json.schemastore.org/tsconfig",
   "display": "Recommended"
 }
-


### PR DESCRIPTION
Updated code base to use new ESM modules syntax, this included the following changes to fix bugs:

- In `tsconfig` file the following properties were added/changed: `"module": "NodeNext"`, `"rootDir": "./src"`, `"moduleResolution: "NodeNext"`, `"baseURL: "./"` 
- In `package.json` the `"type"` property was added with value `"module"`
- In `index.ts`:
  -  `"express"` and `"cors"` require statements were changed to use `import` syntax
  - `"dotenv/config"` is imported directly , this removes the need to call `config()`
- In `expressServices` , `socketServices` and `mongoService` changed require statements to `import` syntax 
- Mongoose does not have default exports for esm modules in its latest version so this required me to break the import statements into two separate parts, on lines 3-4 in `expressServices` and lines 3-4 in `mongoService` 
- For imports referencing specific files in our application, for example `MgRequest` on line 5 in `socketServices`, the `.js` file extension is now required. It is recommended to use the `.js` extension over `.ts` since `.js` is the module loaded at compile time.
